### PR TITLE
Marking analyzers as private assets

### DIFF
--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/WheresLou.Server.Kestrel.Transport.InlineSockets.csproj
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/WheresLou.Server.Kestrel.Transport.InlineSockets.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Should not be a dependency in the packaged result