### PR TITLE
Adding logger service interfaces

### DIFF
--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Connection.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Connection.cs
@@ -15,18 +15,19 @@ using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.Extensions.Logging;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
 
+
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public partial class Connection : TransportConnection, IConnection, IDuplexPipe, IHttpConnectionFeature, IConnectionIdFeature, IConnectionTransportFeature, IMemoryPoolFeature, IApplicationTransportFeature, ITransportSchedulerFeature, IConnectionLifetimeFeature, IConnectionHeartbeatFeature, IConnectionLifetimeNotificationFeature
     {
-        private readonly ConnectionContext<Connection> _context;
+        private readonly ConnectionContext _context;
         private readonly INetworkSocket _socket;
         private readonly CancellationTokenSource _connectionCloseRequestedTokenSource;
         private readonly CancellationTokenSource _connectionClosedTokenSource;
         private readonly PipeReader _connectionPipeReader;
         private readonly PipeWriter _connectionPipeWriter;
-        private readonly EndPoint _socketRemoteEndPoint;
-        private readonly EndPoint _socketLocalEndPoint;
+        private readonly IPEndPoint _socketRemoteEndPoint;
+        private readonly IPEndPoint _socketLocalEndPoint;
         private string _connectionId;
         private IDuplexPipe _applicationDuplexPipe;
         private object _synchronizeCompletion = new object();
@@ -34,7 +35,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
         private bool _pipeReaderComplete;
 
         public Connection(
-            ConnectionContext<Connection> context,
+            ConnectionContext context,
             IConnectionFactory connectionFactory,
             INetworkSocket socket)
         {
@@ -104,25 +105,25 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 
         IPAddress IHttpConnectionFeature.RemoteIpAddress
         {
-            get => ((IPEndPoint)_socketRemoteEndPoint).Address;
+            get => _socketRemoteEndPoint.Address;
             set => throw new NotImplementedException();
         }
 
         IPAddress IHttpConnectionFeature.LocalIpAddress
         {
-            get => ((IPEndPoint)_socketLocalEndPoint).Address;
+            get => _socketLocalEndPoint.Address;
             set => throw new NotImplementedException();
         }
 
         int IHttpConnectionFeature.RemotePort
         {
-            get => ((IPEndPoint)_socketRemoteEndPoint).Port;
+            get => _socketRemoteEndPoint.Port;
             set => throw new NotImplementedException();
         }
 
         int IHttpConnectionFeature.LocalPort
         {
-            get => ((IPEndPoint)_socketLocalEndPoint).Port;
+            get => _socketLocalEndPoint.Port;
             set => throw new NotImplementedException();
         }
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Connection.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Connection.cs
@@ -15,7 +15,6 @@ using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.Extensions.Logging;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
 
-
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public partial class Connection : TransportConnection, IConnection, IDuplexPipe, IHttpConnectionFeature, IConnectionIdFeature, IConnectionTransportFeature, IMemoryPoolFeature, IApplicationTransportFeature, ITransportSchedulerFeature, IConnectionLifetimeFeature, IConnectionHeartbeatFeature, IConnectionLifetimeNotificationFeature

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionContext.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionContext.cs
@@ -2,20 +2,21 @@
 // Licensed under the MIT license.
 
 using Microsoft.Extensions.Logging;
+using WheresLou.Server.Kestrel.Transport.InlineSockets.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
-    public struct ConnectionContext<TCategoryName>
+    public struct ConnectionContext
     {
         public ConnectionContext(
-            ILogger<TCategoryName> logger,
+            IConnectionLogger logger,
             InlineSocketsTransportOptions options)
         {
             Logger = logger;
             Options = options;
         }
 
-        public ILogger<TCategoryName> Logger { get; }
+        public IConnectionLogger Logger { get; }
 
         public InlineSocketsTransportOptions Options { get; }
     }

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionFactory.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionFactory.cs
@@ -2,38 +2,30 @@
 // Licensed under the MIT license.
 
 using System.IO.Pipelines;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
+using WheresLou.Server.Kestrel.Transport.InlineSockets.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public class ConnectionFactory : IConnectionFactory
     {
-        private readonly ILogger<Connection> _connectionLogger;
-        private readonly ILogger<ConnectionPipeReader> _connectionPipeReaderLogger;
-        private readonly ILogger<ConnectionPipeWriter> _connectionPipeWriterLogger;
-        private readonly IOptions<InlineSocketsTransportOptions> _options;
+        private readonly ConnectionContext _context;
 
         public ConnectionFactory(
-            ILogger<Connection> connectionLogger,
-            ILogger<ConnectionPipeReader> connectionPipeReaderLogger,
-            ILogger<ConnectionPipeWriter> connectionPipeWriterLogger,
+            IConnectionLogger connectionLogger,
             IOptions<InlineSocketsTransportOptions> options)
         {
-            _connectionLogger = connectionLogger;
-            _connectionPipeReaderLogger = connectionPipeReaderLogger;
-            _connectionPipeWriterLogger = connectionPipeWriterLogger;
-            _options = options;
+            _context = new ConnectionContext(
+                connectionLogger, 
+                options.Value);
         }
 
         public virtual IConnection CreateConnection(
             INetworkSocket socket)
         {
             return new Connection(
-                new ConnectionContext<Connection>(
-                    _connectionLogger,
-                    _options.Value),
+                _context,
                 this,
                 socket);
         }
@@ -43,9 +35,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             INetworkSocket socket)
         {
             return new ConnectionPipeReader(
-                new ConnectionContext<ConnectionPipeReader>(
-                    _connectionPipeReaderLogger,
-                    _options.Value),
+                _context,
                 connection,
                 socket);
         }
@@ -55,9 +45,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             INetworkSocket socket)
         {
             return new ConnectionPipeWriter(
-                new ConnectionContext<ConnectionPipeWriter>(
-                    _connectionPipeWriterLogger,
-                    _options.Value),
+                _context,
                 connection,
                 socket);
         }

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionFactory.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionFactory.cs
@@ -17,7 +17,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             IOptions<InlineSocketsTransportOptions> options)
         {
             _context = new ConnectionContext(
-                connectionLogger, 
+                connectionLogger,
                 options.Value);
         }
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionPipeReader.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionPipeReader.cs
@@ -13,7 +13,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public class ConnectionPipeReader : PipeReader
     {
-        private readonly ConnectionContext<ConnectionPipeReader> _context;
+        private readonly ConnectionContext _context;
         private readonly IConnection _connection;
         private readonly INetworkSocket _socket;
         private readonly CancellationTokenSource _writerCompleted;
@@ -25,7 +25,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
         private Exception _writerCompletedException;
 
         public ConnectionPipeReader(
-            ConnectionContext<ConnectionPipeReader> context,
+            ConnectionContext context,
             IConnection connection,
             INetworkSocket socket)
         {

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionPipeWriter.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/ConnectionPipeWriter.cs
@@ -12,7 +12,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public class ConnectionPipeWriter : PipeWriter
     {
-        private readonly ConnectionContext<ConnectionPipeWriter> _context;
+        private readonly ConnectionContext _context;
         private readonly IConnection _connection;
         private readonly INetworkSocket _socket;
         private readonly CancellationTokenSource _readerCompleted;
@@ -23,7 +23,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
         private Exception _readerCompletedException;
 
         public ConnectionPipeWriter(
-            ConnectionContext<ConnectionPipeWriter> context,
+            ConnectionContext context,
             IConnection connection,
             INetworkSocket socket)
         {

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/InlineSocketsTransportServiceCollectionExtensions.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/InlineSocketsTransportServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.Extensions.Options;
 using WheresLou.Server.Kestrel.Transport.InlineSockets;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
+using WheresLou.Server.Kestrel.Transport.InlineSockets.Logging;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -16,7 +17,9 @@ namespace Microsoft.Extensions.DependencyInjection
                 .AddTransient<IConfigureOptions<InlineSocketsTransportOptions>, InlineSocketsTransportOptionsDefaults>()
                 .AddTransient<ITransportFactory, TransportFactory>()
                 .AddTransient<IConnectionFactory, ConnectionFactory>()
-                .AddTransient<INetworkProvider, NetworkProvider>();
+                .AddTransient<INetworkProvider, NetworkProvider>()
+                .AddTransient<ITransportLogger, TransportLogger>()
+                .AddTransient<IConnectionLogger, ConnectionLogger>();
         }
     }
 }

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Internals/INetworkSocket.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Internals/INetworkSocket.cs
@@ -11,9 +11,9 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Internals
 {
     public interface INetworkSocket : IDisposable
     {
-        EndPoint LocalEndPoint { get; }
+        IPEndPoint LocalEndPoint { get; }
 
-        EndPoint RemoteEndPoint { get; }
+        IPEndPoint RemoteEndPoint { get; }
 
         int Send(ReadOnlySequence<byte> buffers);
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Internals/NetworkSocket.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Internals/NetworkSocket.cs
@@ -28,9 +28,9 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Internals
             _receiveEventArgs.Completed += ReceiveAsyncCompleted;
         }
 
-        public virtual EndPoint LocalEndPoint => _socket.LocalEndPoint;
+        public virtual IPEndPoint LocalEndPoint => (IPEndPoint)_socket.LocalEndPoint;
 
-        public virtual EndPoint RemoteEndPoint => _socket.RemoteEndPoint;
+        public virtual IPEndPoint RemoteEndPoint => (IPEndPoint)_socket.RemoteEndPoint;
 
         public virtual void Dispose()
         {

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ConnectionLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ConnectionLogger.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    public class ConnectionLogger : ForwardingLogger, IConnectionLogger
+    {
+        public ConnectionLogger(ILoggerFactory loggerFactory)
+            : base(loggerFactory, typeof(Connection).FullName)
+        {
+        }
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ConnectionLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ConnectionLogger.cs
@@ -1,4 +1,7 @@
-﻿using System;
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
 using Microsoft.Extensions.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ForwardingLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ForwardingLogger.cs
@@ -1,0 +1,30 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    public abstract class ForwardingLogger : ILogger
+    {
+        private readonly ILogger _logger;
+
+        public ForwardingLogger(ILoggerFactory loggerFactory, string categoryName)
+        {
+            _logger = loggerFactory.CreateLogger(categoryName);
+        }
+
+        public virtual IDisposable BeginScope<TState>(TState state)
+        {
+            return _logger.BeginScope(state);
+        }
+
+        public virtual bool IsEnabled(LogLevel logLevel)
+        {
+            return _logger.IsEnabled(logLevel);
+        }
+
+        public virtual void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+        {
+            _logger.Log(logLevel, eventId, state, exception, formatter);
+        }
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ForwardingLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ForwardingLogger.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/IConnectionLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/IConnectionLogger.cs
@@ -1,0 +1,8 @@
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    public interface IConnectionLogger : ILogger
+    {
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/IConnectionLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/IConnectionLogger.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 using Microsoft.Extensions.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ITransportLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ITransportLogger.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 using System;
 using System.Net;
 using Microsoft.Extensions.Logging;

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ITransportLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/ITransportLogger.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    public interface ITransportLogger : ILogger
+    {
+        void BindListenSocket(IPEndPoint ipEndPoint);
+
+        void UnbindListenSocket(IPEndPoint ipEndPoint);
+
+        void StopTransport();
+
+        void SocketAccepted(EndPoint remoteEndPoint, EndPoint localEndPoint);
+
+        void ConnectionDispatchFailed(Exception error);
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/LoggerMessage.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/LoggerMessage.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 using System;
 using Microsoft.Extensions.Logging;
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/LoggerMessage.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/LoggerMessage.cs
@@ -1,0 +1,32 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    internal struct LoggerMessage
+    {
+        public Action<ILogger, Exception> Log { get; private set; }
+
+        public static implicit operator LoggerMessage((LogLevel logLevel, EventId eventId, string message) details) => new LoggerMessage { Log = Microsoft.Extensions.Logging.LoggerMessage.Define(details.logLevel, details.eventId, details.message) };
+
+        public static implicit operator LoggerMessage((LogLevel logLevel, int eventId, string eventName, string message) details) => new LoggerMessage { Log = Microsoft.Extensions.Logging.LoggerMessage.Define(details.logLevel, new EventId(details.eventId, details.eventName), details.message) };
+    }
+
+    internal struct LoggerMessage<T1>
+    {
+        public Action<ILogger, T1, Exception> Log { get; private set; }
+
+        public static implicit operator LoggerMessage<T1>((LogLevel logLevel, EventId eventId, string message) details) => new LoggerMessage<T1> { Log = Microsoft.Extensions.Logging.LoggerMessage.Define<T1>(details.logLevel, details.eventId, details.message) };
+
+        public static implicit operator LoggerMessage<T1>((LogLevel logLevel, int eventId, string eventName, string message) details) => new LoggerMessage<T1> { Log = Microsoft.Extensions.Logging.LoggerMessage.Define<T1>(details.logLevel, new EventId(details.eventId, details.eventName), details.message) };
+    }
+
+    internal struct LoggerMessage<T1, T2>
+    {
+        public Action<ILogger, T1, T2, Exception> Log { get; private set; }
+
+        public static implicit operator LoggerMessage<T1, T2>((LogLevel logLevel, EventId eventId, string message) details) => new LoggerMessage<T1, T2> { Log = Microsoft.Extensions.Logging.LoggerMessage.Define<T1, T2>(details.logLevel, details.eventId, details.message) };
+
+        public static implicit operator LoggerMessage<T1, T2>((LogLevel logLevel, int eventId, string eventName, string message) details) => new LoggerMessage<T1, T2> { Log = Microsoft.Extensions.Logging.LoggerMessage.Define<T1, T2>(details.logLevel, new EventId(details.eventId, details.eventName), details.message) };
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/TransportLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/TransportLogger.cs
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
 using System;
 using System.Net;
 using Microsoft.Extensions.Logging;

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/TransportLogger.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Logging/TransportLogger.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Net;
+using Microsoft.Extensions.Logging;
+
+namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Logging
+{
+    public class TransportLogger : ForwardingLogger, ITransportLogger
+    {
+        private static readonly LoggerMessage<IPEndPoint> _logBindListenSocket = (LogLevel.Debug, 1, "BindListenSocket", "Binding listen socket to {IPEndPoint}");
+        private static readonly LoggerMessage<IPEndPoint> _logUnbindListenSocket = (LogLevel.Debug, 2, "UnbindListenSocket", "Unbinding listen socket from {IPEndPoint}");
+        private static readonly LoggerMessage _logStopTransport = (LogLevel.Debug, 3, "StopTransport", "Inline sockets transport is stopped");
+        private static readonly LoggerMessage<EndPoint, EndPoint> _logSocketAccepted = (LogLevel.Information, 4, "SocketAccepted", "Socket accepted from {RemoteEndPoint} to {LocalEndPoint}");
+        private static readonly LoggerMessage _logConnectionDispatchFailed = (LogLevel.Debug, 5, "ConnectionDispatchFailed", "Unexpected failure thrown from IConnectionDispatcher.OnConnection");
+
+        public TransportLogger(ILoggerFactory loggerFactory)
+            : base(loggerFactory, typeof(Transport).FullName)
+        {
+        }
+
+        public virtual void BindListenSocket(IPEndPoint ipEndPoint) => _logBindListenSocket.Log(this, ipEndPoint, null);
+
+        public virtual void UnbindListenSocket(IPEndPoint ipEndPoint) => _logUnbindListenSocket.Log(this, ipEndPoint, null);
+
+        public virtual void StopTransport() => _logStopTransport.Log(this, null);
+
+        public virtual void SocketAccepted(EndPoint remoteEndPoint, EndPoint localEndPoint) => _logSocketAccepted.Log(this, remoteEndPoint, localEndPoint, null);
+
+        public virtual void ConnectionDispatchFailed(Exception error) => _logConnectionDispatchFailed.Log(this, error);
+    }
+}

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Transport.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/Transport.cs
@@ -6,7 +6,6 @@ using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
-using Microsoft.Extensions.Logging;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
@@ -33,7 +32,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 
         public Task BindAsync()
         {
-            _context.Logger.LogDebug(new EventId(1, "BindListenSocket"), "Binding listen socket to {IPEndPoint}", _endPointInformation.IPEndPoint);
+            _context.Logger.BindListenSocket(_endPointInformation.IPEndPoint);
 
             _listener = _context.NetworkProvider.CreateListener(new NetworkListenerSettings
             {
@@ -53,7 +52,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 
         public async Task UnbindAsync()
         {
-            _context.Logger.LogDebug(new EventId(2, "UnbindListenSocket"), "Unbinding listen socket from {IPEndPoint}", _endPointInformation.IPEndPoint);
+            _context.Logger.UnbindListenSocket(_endPointInformation.IPEndPoint);
 
             _acceptLoopTokenSource.Cancel(throwOnFirstException: false);
             _listener.Stop();
@@ -65,7 +64,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 
         public Task StopAsync()
         {
-            _context.Logger.LogDebug(new EventId(3, "StopTransport"), "Inline sockets transport is stopped.");
+            _context.Logger.StopTransport();
             return Task.CompletedTask;
         }
 
@@ -77,7 +76,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
                 {
                     var socket = await listener.AcceptSocketAsync();
 
-                    _context.Logger.LogInformation(new EventId(5, "SocketAccepted"), "Socket accepted from {RemoteEndPoint} to {LocalEndPoint}", socket.RemoteEndPoint, socket.LocalEndPoint);
+                    _context.Logger.SocketAccepted(socket.RemoteEndPoint, socket.LocalEndPoint);
 
                     var task = Task.Run(() => ProcessSocketAsync(socket, cancellationToken));
 
@@ -104,7 +103,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             }
             catch (Exception ex)
             {
-                _context.Logger.LogError(new EventId(6, "OnConnectionError"), ex, "Unexpected failure thrown from IConnectionDispatcher.OnConnection");
+                _context.Logger.ConnectionDispatchFailed(ex);
             }
         }
 
@@ -113,11 +112,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             var connection = _context.ConnectionFactory.CreateConnection(socket);
             try
             {
-                _context.Logger.LogTrace("TODO: Connection dispatch starting");
-
                 await _connectionDispatcher.OnConnection(connection.TransportConnection);
-
-                _context.Logger.LogTrace("TODO: Connection dispatch complete");
             }
             finally
             {

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/TransportContext.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/TransportContext.cs
@@ -1,15 +1,15 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-using Microsoft.Extensions.Logging;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
+using WheresLou.Server.Kestrel.Transport.InlineSockets.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
     public struct TransportContext
     {
         public TransportContext(
-            ILogger<Transport> logger,
+            ITransportLogger logger,
             InlineSocketsTransportOptions options,
             INetworkProvider networkProvider,
             IConnectionFactory connectionFactory)
@@ -20,7 +20,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
             ConnectionFactory = connectionFactory;
         }
 
-        public ILogger<Transport> Logger { get; }
+        public ITransportLogger Logger { get; }
 
         public InlineSocketsTransportOptions Options { get; }
 

--- a/src/WheresLou.Server.Kestrel.Transport.InlineSockets/TransportFactory.cs
+++ b/src/WheresLou.Server.Kestrel.Transport.InlineSockets/TransportFactory.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT license.
 
 using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using WheresLou.Server.Kestrel.Transport.InlineSockets.Internals;
+using WheresLou.Server.Kestrel.Transport.InlineSockets.Logging;
 
 namespace WheresLou.Server.Kestrel.Transport.InlineSockets
 {
@@ -13,7 +13,7 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets
         private readonly TransportContext _context;
 
         public TransportFactory(
-            ILogger<Transport> logger,
+            ITransportLogger logger,
             IOptions<InlineSocketsTransportOptions> options,
             INetworkProvider networkProvider,
             IConnectionFactory connectionFactory)

--- a/test/WheresLou.Server.Kestrel.Transport.InlineSockets.Tests/Http1Tests.cs
+++ b/test/WheresLou.Server.Kestrel.Transport.InlineSockets.Tests/Http1Tests.cs
@@ -88,7 +88,8 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Tests
         [Fact]
         public async Task ServerAcceptsPostBody()
         {
-            using (var services = new ServicesFixture())
+            using (var logging = new LoggingFixture())
+            using (var services = new ServicesFixture(logging))
             using (var app = new AppFixture())
             using (var client = new HttpClient())
             using (var timeout = new CancellationTokenSource(Debugger.IsAttached ? TimeSpan.FromMinutes(5) : TimeSpan.FromSeconds(2.5)))

--- a/test/WheresLou.Server.Kestrel.Transport.InlineSockets.Tests/Stubs/TestNetworkSocket.cs
+++ b/test/WheresLou.Server.Kestrel.Transport.InlineSockets.Tests/Stubs/TestNetworkSocket.cs
@@ -12,9 +12,9 @@ namespace WheresLou.Server.Kestrel.Transport.InlineSockets.Tests.Stubs
 {
     public class TestNetworkSocket : INetworkSocket
     {
-        public EndPoint LocalEndPoint { get; set; }
+        public IPEndPoint LocalEndPoint { get; set; }
 
-        public EndPoint RemoteEndPoint { get; set; }
+        public IPEndPoint RemoteEndPoint { get; set; }
 
         public bool IsDisposed { get; set; }
 


### PR DESCRIPTION
`ITransportLogger` and `IConnectionLogger` may be replaced to send telemetry directly to additional locations. `TransportLogger` and `ConnectionLogger` are designed to be sub-classed to keep default logging in place.

Fixes #12 