### PR TITLE
Enable application to schedule inline

### DIFF
--- a/examples/HelloWorld/Program.cs
+++ b/examples/HelloWorld/Program.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -20,8 +21,14 @@ namespace HelloWorld
             CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHostBuilder CreateWebHostBuilder(string[] args) =>
-            WebHost.CreateDefaultBuilder(args)
-                .UseStartup<Startup>();
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
+        {
+            return WebHost.CreateDefaultBuilder(args)
+                .UseStartup<Startup>()
+                .ConfigureKestrel(options =>
+                {
+                    options.ApplicationSchedulingMode = SchedulingMode.Inline;
+                });
+        }
     }
 }


### PR DESCRIPTION
Transport layer shouldn't need to implement worker thread
hop in order to protect accept loop