### PR TITLE
Each test should use a different server port

### DIFF
--- a/src/Microsoft.Bing.AspNetCore.Connections.InlineSocket/Connection.cs
+++ b/src/Microsoft.Bing.AspNetCore.Connections.InlineSocket/Connection.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket
 
         public virtual string ConnectionId
         {
-            get => _connectionId ?? Interlocked.CompareExchange(ref _connectionId, CorrelationIdGenerator.GetNextId(), null);
+            get => _connectionId ?? Interlocked.CompareExchange(ref _connectionId, CorrelationIdGenerator.GetNextId(), null) ?? _connectionId;
             set => _connectionId = value;
         }
 

--- a/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/ClientFixture.cs
+++ b/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/ClientFixture.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests.Fixtures;
+
+namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers.Fixtures
+{
+    public class ClientFixture
+    {
+        private readonly EndPointFixture _endPoint;
+        private readonly HttpClient _httpClient;
+        private readonly TimeoutFixture _timeout;
+
+        public ClientFixture(EndPointFixture endPoint, HttpClient httpClient, TimeoutFixture timeout)
+        {
+            _endPoint = endPoint;
+            _httpClient = httpClient;
+            _timeout = timeout;
+        }
+
+        public async Task<HttpResponseMessage> GetAsync(string path)
+        {
+            return await _httpClient.GetAsync(_endPoint.Address + path, HttpCompletionOption.ResponseHeadersRead, _timeout.Token);
+        }
+
+        public async Task<(HttpResponseMessage response, string content)> GetStringAsync(string path)
+        {
+            var response = await GetAsync(path);
+            return (response, await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<HttpResponseMessage> PostAsync(string path, HttpContent content)
+        {
+            return await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Post, _endPoint.Address + path) { Content = content }, HttpCompletionOption.ResponseHeadersRead, _timeout.Token);
+        }
+
+        public async Task<(HttpResponseMessage response, string content)> PostStringAsync(string path, HttpContent content)
+        {
+            var response = await GetAsync(path);
+            return (response, await response.Content.ReadAsStringAsync());
+        }
+
+        public async Task<(HttpResponseMessage response, byte[] content)> PostBytesAsync(string path, HttpContent content)
+        {
+            var response = await GetAsync(path);
+            return (response, await response.Content.ReadAsByteArrayAsync());
+        }
+    }
+}

--- a/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/EndPointFixture.cs
+++ b/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/EndPointFixture.cs
@@ -9,7 +9,11 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests.Fixtures
 {
     public class EndPointFixture
     {
-        public IPEndPoint IPEndPoint { get; set; } 
+        public IPEndPoint IPEndPoint { get; set; }
+        
+        public string Scheme { get; set; } = "http";
+        
+        public string Address => $"{Scheme}://{IPEndPoint}";
 
         public void FindUnusedPort()
         {

--- a/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/ServerFixture.cs
+++ b/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/Fixtures/ServerFixture.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests.Fixtures;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,36 +13,43 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers.Fixture
         private readonly TimeoutFixture _timeout;
         private readonly ServicesFixture _services;
         private readonly AppFixture _app;
+        private readonly EndPointFixture _endPoint;
         private IServer _server;
 
         public ServerFixture(
             TimeoutFixture timeout,
             ServicesFixture services,
-            AppFixture app)
+            AppFixture app,
+            EndPointFixture endPoint)
         {
             _timeout = timeout;
             _services = services;
             _app = app;
+            _endPoint = endPoint;
         }
+
+        public IServer Server => _server ?? Interlocked.CompareExchange(ref _server, _services.GetService<IServer>(), null) ?? _server;
 
         public async Task StartAsync()
         {
-            _server = _services.GetService<IServer>();
-            await _server.StartAsync(_app, _timeout.Token);
+            _endPoint.FindUnusedPort();
+
+            var serverAddresses = Server.Features.Get<IServerAddressesFeature>();
+            serverAddresses.Addresses.Clear();
+            serverAddresses.Addresses.Add(_endPoint.Address);
+
+            await Server.StartAsync(_app, _timeout.Token);
         }
 
         public async Task StopAsync()
         {
-            if (_server != null)
-            {
-                await _server.StopAsync(_timeout.Token);
-                _server = null;
-            }
+            await Server.StopAsync(_timeout.Token);
         }
 
         public void Dispose()
         {
-            StopAsync().GetAwaiter().GetResult();
+            _server?.Dispose();
+            _server = null;
         }
     }
 }

--- a/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/TestContext.cs
+++ b/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers/TestContext.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers
                 .AddSingleton<TimeoutFixture>()
                 .AddSingleton<HttpClient>()
                 .AddSingleton<OptionsFixture>()
+                .AddSingleton<ClientFixture>()
                 .BuildServiceProvider();
         }
 
@@ -30,8 +31,8 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.TestHelpers
         public ServerFixture Server => _fixtures.GetService<ServerFixture>();
         public ServicesFixture Services => _fixtures.GetService<ServicesFixture>();
         public TimeoutFixture Timeout => _fixtures.GetService<TimeoutFixture>();
-        public HttpClient Client => _fixtures.GetService<HttpClient>();
         public OptionsFixture Options => _fixtures.GetService<OptionsFixture>();
+        public ClientFixture Client => _fixtures.GetService<ClientFixture>();
 
         public void Dispose()
         {

--- a/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests.V3/Http1Tests.cs
+++ b/test/Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests.V3/Http1Tests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
 
             await test.Server.StartAsync();
 
-            var responseMessage = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
+            var responseMessage = await test.Client.GetAsync("/");
 
             var responseBody = await responseMessage.Content.ReadAsStringAsync();
 
@@ -59,9 +59,9 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
 
             await test.Server.StartAsync();
 
-            var response1 = await test.Client.GetAsync("http://localhost:5000/request1", test.Timeout.Token);
-            var response2 = await test.Client.GetAsync("http://localhost:5000/request2", test.Timeout.Token);
-            var response3 = await test.Client.GetAsync("http://localhost:5000/request3", test.Timeout.Token);
+            var response1 = await test.Client.GetAsync("/request1");
+            var response2 = await test.Client.GetAsync("/request2");
+            var response3 = await test.Client.GetAsync("/request3");
         }
 
         [Fact]
@@ -88,10 +88,9 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
 
             await test.Server.StartAsync();
 
-            var response1 = await test.Client.PostAsync("http://localhost:5000/", new StringContent("Request Data One"), test.Timeout.Token);
-            var response2 = await test.Client.PostAsync("http://localhost:5000/", new StringContent("Request Data Two"), test.Timeout.Token);
-            var response3 = await test.Client.PostAsync("http://localhost:5000/", new StringContent("Request Data Three"), test.Timeout.Token);
-
+            var response1 = await test.Client.PostStringAsync("/", new StringContent("Request Data One"));
+            var response2 = await test.Client.PostStringAsync("/", new StringContent("Request Data Two"));
+            var response3 = await test.Client.PostStringAsync("/", new StringContent("Request Data Three"));
         }
 
         [Fact]
@@ -122,19 +121,15 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
             random.NextBytes(bytes2);
             random.NextBytes(bytes3);
 
-            var response1 = await test.Client.PostAsync("http://localhost:5000/", new ByteArrayContent(bytes1), test.Timeout.Token);
-            var response2 = await test.Client.PostAsync("http://localhost:5000/", new ByteArrayContent(bytes2), test.Timeout.Token);
-            var response3 = await test.Client.PostAsync("http://localhost:5000/", new ByteArrayContent(bytes3), test.Timeout.Token);
+            var response1 = await test.Client.PostBytesAsync("/", new ByteArrayContent(bytes1));
+            var response2 = await test.Client.PostBytesAsync("/", new ByteArrayContent(bytes2));
+            var response3 = await test.Client.PostBytesAsync("/", new ByteArrayContent(bytes3));
 
             await test.Server.StopAsync();
 
-            var body1 = await response1.Content.ReadAsByteArrayAsync();
-            var body2 = await response2.Content.ReadAsByteArrayAsync();
-            var body3 = await response3.Content.ReadAsByteArrayAsync();
-
-            Assert.All(body1.Zip(bytes1, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
-            Assert.All(body2.Zip(bytes2, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
-            Assert.All(body3.Zip(bytes3, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
+            Assert.All(response1.content.Zip(bytes1, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
+            Assert.All(response2.content.Zip(bytes2, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
+            Assert.All(response3.content.Zip(bytes3, (a, b) => (a, b)), pair => Assert.Equal(pair.a, pair.b));
         }
 
         [Fact]
@@ -160,9 +155,9 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
 
             await test.Server.StartAsync();
 
-            var response1 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
-            var response2 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
-            var response3 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
+            var response1 = await test.Client.GetStringAsync("/");
+            var response2 = await test.Client.GetStringAsync("/");
+            var response3 = await test.Client.GetStringAsync("/");
 
             Assert.Single(connectionIds.Distinct());
 
@@ -193,9 +188,9 @@ namespace Microsoft.Bing.AspNetCore.Connections.InlineSocket.Tests
 
             await test.Server.StartAsync();
 
-            var response1 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
-            var response2 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
-            var response3 = await test.Client.GetAsync("http://localhost:5000/", test.Timeout.Token);
+            var response1 = await test.Client.GetStringAsync("/");
+            var response2 = await test.Client.GetStringAsync("/");
+            var response3 = await test.Client.GetStringAsync("/");
 
             Assert.Equal(3, connectionIds.Distinct().Count());
 


### PR DESCRIPTION
Default server port causes unit test collisions fairly regularly